### PR TITLE
invalid table name in migration.  survey_tentatives should be survey_attempts

### DIFF
--- a/lib/generators/templates/migration.rb
+++ b/lib/generators/templates/migration.rb
@@ -50,7 +50,7 @@ class CreateSurvey < ActiveRecord::Migration
     drop_table :survey_questions
     drop_table :survey_options
 
-    drop_table :survey_tentatives
+    drop_table :survey_attempts
     drop_table :survey_answers
   end
 end


### PR DESCRIPTION
the self.down command breaks because if an invalid table name.

This commit simply changes survey_tentatives to survey_attempts.
