### PR TITLE
Use Bundler's github shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ http://rubydoc.info/github/runtimerevolution/survey/frames
 
 Add survey to your Gemfile:
 ```ruby
-gem 'survey', :git => 'git://github.com/runtimerevolution/survey.git'
+gem 'survey', :github => 'runtimerevolution/survey'
 
 ```
 Then run bundle to install the Gem:


### PR DESCRIPTION
Bundler has a nice shortcut to install repositories from GitHub. As a side note, why haven't you registered the gem on rubygems.org yet? It's awesome, and the name is still available!
