### PR TITLE
Add Ruby 2.1.0 to Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0


### PR DESCRIPTION
Add Ruby 2.1.0 to Travis configuration file to test Survey with ruby 2.1.0
