### PR TITLE
Corrected spelling error on Survey Controller alert text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,7 @@
 en:
   surveys_controller:
-    create: Your Survey has been successfull created
-    update: Your Survey has been successfull updated
+    create: Your Survey has been successfully created
+    update: Your Survey has been successfully updated
   attempts_controller:
     create: "Congratulations, you have responded to Survey."
   surveys: Surveys


### PR DESCRIPTION
Fix spelling problem reported on issue #34.

No performance or database changes.

Files changed:
config/locales/en.yml
