### PR TITLE
 Deprecation Fix for avaliable_for_participation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,14 @@ end
 
 ## Survey inside your Views
 
-### Controlling Survey avaliability per participant
-To control which page participants see you can use method `avaliable_for_participant?`
+### Controlling Survey availability per participant
+NOTE: avaliable_for_participant? method has been deprecated. Please use
+available_for_participant? method instead.
+
+To control which page participants see you can use method `available_for_participant?`
 that checks if the participant already spent his attempts.
 ```erb
-<% if @survey.avaliable_for_participant?(@participant) %>
+<% if @survey.available_for_participant?(@participant) %>
   <%= render 'form' %>
 <% else %>
   Uupss, <%= @participant.name %> you have reach the maximum number of

--- a/lib/generators/templates/attempts_views/new.html.erb
+++ b/lib/generators/templates/attempts_views/new.html.erb
@@ -2,7 +2,7 @@
   <p>
     <%= @participant.email %> there are not Active Surveys right now.
   </p>
-<% elsif @survey.avaliable_for_participant?(@participant) %>
+<% elsif @survey.available_for_participant?(@participant) %>
   <%= render 'form' %>
 <% else %>
   <p>


### PR DESCRIPTION
 * Added a note to the README stating that
   avaliable_for_participation? method has been
   deprecated.
 * Changed the html file in
   /lib/generators/templates/attempts_views/new.html.erb
   to make use of available_for_participation? method.