### PR TITLE
Rails 5

### DIFF
--- a/app/models/survey/attempt.rb
+++ b/app/models/survey/attempt.rb
@@ -25,7 +25,7 @@ class Survey::Attempt < ActiveRecord::Base
   scope :for_survey, ->(survey) { where(:survey_id => survey.id) }
   scope :exclude_survey,  ->(survey) { where("NOT survey_id = #{survey.id}") }
   scope :for_participant, ->(participant) {
-    where(:participant_id => participant.try(:id), :participant_type => participant.class.base_class)
+    where(:participant_id => participant.try(:id), :participant_type => participant.class.base_class.to_s)
   }
 
   # callbacks

--- a/lib/generators/templates/migration.rb
+++ b/lib/generators/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreateSurvey < ActiveRecord::Migration
+class CreateSurvey < ActiveRecord::Migration[4.2]
   def self.up
 
     # survey surveys logic

--- a/lib/survey.rb
+++ b/lib/survey.rb
@@ -1,10 +1,14 @@
 module ::Kernel
+  def rails5?
+    return defined?(Rails) && Rails::VERSION::MAJOR == 5
+  end
+
   def rails4?
     return defined?(Rails) && Rails::VERSION::MAJOR == 4
   end
 
   def in_rails_3(&block)
-    yield if block_given? unless rails4?
+    yield if block_given? unless rails4? || rails5?
   end
 end
 

--- a/survey.gemspec
+++ b/survey.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |s|
   s.authors     = %Q{Runtime Revolution}
   s.require_paths = %w(lib)
 
-  s.add_dependency("rails", [">= 3.2.6", "< 5"])
-  s.add_dependency("railties", ">= 3.2.6", "< 5")
+  s.add_dependency("rails", [">= 3.2.6", "< 6"])
+  s.add_dependency("railties", ">= 3.2.6", "< 6")
   s.add_development_dependency("mocha")
   s.add_development_dependency("faker")
   s.add_development_dependency("rake")


### PR DESCRIPTION
Now survey seems to work with Rails 5. 

There was a snippet of code in `lib/survey.rb`
```ruby
  def rails4?
    return defined?(Rails) && Rails::VERSION::MAJOR == 4
  end

  def in_rails_3(&block)
    yield if block_given? unless rails4?
  end
```

Perhaps it should be replaced with something like that?

```ruby
def rails3?
  return defined?(Rails) && Rails::VERSION::MAJOR < 4
end

def in_rails_3(&block)
  yield if block_given? && rails3?
end
```